### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE-APACHE2
+++ b/LICENSE-APACHE2
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/sysmon_handler.hrl
+++ b/include/sysmon_handler.hrl
@@ -6,7 +6,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/sysmon_handler_app.erl
+++ b/src/sysmon_handler_app.erl
@@ -6,7 +6,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/sysmon_handler_example_handler.erl
+++ b/src/sysmon_handler_example_handler.erl
@@ -6,7 +6,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/sysmon_handler_filter.erl
+++ b/src/sysmon_handler_filter.erl
@@ -6,7 +6,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/sysmon_handler_sup.erl
+++ b/src/sysmon_handler_sup.erl
@@ -6,7 +6,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/sysmon_handler_testhandler.erl
+++ b/src/sysmon_handler_testhandler.erl
@@ -6,7 +6,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/test/sysmon_handler_SUITE.erl
+++ b/test/sysmon_handler_SUITE.erl
@@ -6,7 +6,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 8 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).